### PR TITLE
Cherrypick Lbaas HA Patches

### DIFF
--- a/neutron/agent/linux/external_process.py
+++ b/neutron/agent/linux/external_process.py
@@ -61,7 +61,8 @@ class ProcessManager(MonitoredProcess):
     """
     def __init__(self, conf, uuid, namespace=None, service=None,
                  pids_path=None, default_cmd_callback=None,
-                 cmd_addl_env=None, pid_file=None, run_as_root=False):
+                 cmd_addl_env=None, pid_file=None, run_as_root=False,
+                 custom_reload_callback=None):
 
         self.conf = conf
         self.uuid = uuid
@@ -71,6 +72,7 @@ class ProcessManager(MonitoredProcess):
         self.pids_path = pids_path or self.conf.external_pids
         self.pid_file = pid_file
         self.run_as_root = run_as_root
+        self.custom_reload_callback = custom_reload_callback
 
         if service:
             self.service_pid_fname = 'pid.' + service
@@ -94,7 +96,10 @@ class ProcessManager(MonitoredProcess):
             self.reload_cfg()
 
     def reload_cfg(self):
-        self.disable('HUP')
+        if self.custom_reload_callback:
+            self.disable(get_stop_command=self.custom_reload_callback)
+        else:
+            self.disable('HUP')
 
     def disable(self, sig='9', get_stop_command=None):
         pid = self.pid

--- a/neutron/db/agentschedulers_db.py
+++ b/neutron/db/agentschedulers_db.py
@@ -19,6 +19,7 @@ import time
 
 from oslo_config import cfg
 from oslo_log import log as logging
+import oslo_messaging
 from oslo_service import loopingcall
 from oslo_utils import timeutils
 import sqlalchemy as sa
@@ -155,6 +156,63 @@ class AgentSchedulerDbMixin(agents_db.AgentDbMixin):
         cutoff = timeutils.utcnow() - datetime.timedelta(
             seconds=agent_dead_limit)
         return cutoff
+
+    def reschedule_resources_from_down_agents(self, agent_type,
+                                              get_down_bindings,
+                                              agent_id_attr,
+                                              resource_id_attr,
+                                              resource_name,
+                                              reschedule_resource,
+                                              rescheduling_failed):
+        """Reschedule resources from down neutron agents
+        if admin state is up.
+        """
+        agent_dead_limit = self.agent_dead_limit_seconds()
+        self.wait_down_agents(agent_type, agent_dead_limit)
+
+        context = ncontext.get_admin_context()
+        try:
+            down_bindings = get_down_bindings(context, agent_dead_limit)
+
+            agents_back_online = set()
+            for binding in down_bindings:
+                binding_agent_id = getattr(binding, agent_id_attr)
+                binding_resource_id = getattr(binding, resource_id_attr)
+                if binding_agent_id in agents_back_online:
+                    continue
+                else:
+                    # we need new context to make sure we use different DB
+                    # transaction - otherwise we may fetch same agent record
+                    # each time due to REPEATABLE_READ isolation level
+                    context = ncontext.get_admin_context()
+                    agent = self._get_agent(context, binding_agent_id)
+                    if agent.is_active:
+                        agents_back_online.add(binding_agent_id)
+                        continue
+
+                LOG.warning(_LW(
+                    "Rescheduling %(resource_name)s %(resource)s from agent "
+                    "%(agent)s because the agent did not report to the server "
+                    "in the last %(dead_time)s seconds."),
+                    {'resource_name': resource_name,
+                     'resource': binding_resource_id,
+                     'agent': binding_agent_id,
+                     'dead_time': agent_dead_limit})
+                try:
+                    reschedule_resource(context, binding_resource_id)
+                except (rescheduling_failed, oslo_messaging.RemoteError):
+                    # Catch individual rescheduling errors here
+                    # so one broken one doesn't stop the iteration.
+                    LOG.exception(_LE("Failed to reschedule %(resource_name)s "
+                                      "%(resource)s"),
+                                  {'resource_name': resource_name,
+                                   'resource': binding_resource_id})
+        except Exception:
+            # we want to be thorough and catch whatever is raised
+            # to avoid loop abortion
+            LOG.exception(_LE("Exception encountered during %(resource_name)s "
+                              "rescheduling."),
+                          {'resource_name': resource_name})
 
 
 class DhcpAgentSchedulerDbMixin(dhcpagentscheduler

--- a/neutron/db/l3_agentschedulers_db.py
+++ b/neutron/db/l3_agentschedulers_db.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy import sql
 
 from neutron._i18n import _, _LI
-from neutron.common import constants as n_const
+from neutron.common import constants #as n_const
 from neutron.common import utils as n_utils
 from neutron.db import agents_db
 from neutron.db import agentschedulers_db

--- a/neutron/db/l3_agentschedulers_db.py
+++ b/neutron/db/l3_agentschedulers_db.py
@@ -25,10 +25,9 @@ from sqlalchemy import orm
 from sqlalchemy.orm import joinedload
 from sqlalchemy import sql
 
-from neutron._i18n import _, _LE, _LI, _LW
-from neutron.common import constants
+from neutron._i18n import _, _LI
+from neutron.common import constants as n_const
 from neutron.common import utils as n_utils
-from neutron import context as n_ctx
 from neutron.db import agents_db
 from neutron.db import agentschedulers_db
 from neutron.db import l3_attrs_db
@@ -92,59 +91,27 @@ class L3AgentSchedulerDbMixin(l3agentscheduler.L3AgentSchedulerPluginBase,
 
     def reschedule_routers_from_down_agents(self):
         """Reschedule routers from down l3 agents if admin state is up."""
-        agent_dead_limit = self.agent_dead_limit_seconds()
-        self.wait_down_agents('L3', agent_dead_limit)
-        cutoff = self.get_cutoff_time(agent_dead_limit)
+        self.reschedule_resources_from_down_agents(
+                agent_type='L3',
+                get_down_bindings=self.get_down_router_bindings,
+                agent_id_attr='l3_agent_id',
+                resource_id_attr='router_id',
+                resource_name='router',
+                reschedule_resource=self.reschedule_router,
+                rescheduling_failed=l3agentscheduler.RouterReschedulingFailed)
 
-        context = n_ctx.get_admin_context()
-        try:
-            down_bindings = (
-                context.session.query(RouterL3AgentBinding).
-                join(agents_db.Agent).
-                filter(agents_db.Agent.heartbeat_timestamp < cutoff,
-                       agents_db.Agent.admin_state_up).
-                outerjoin(l3_attrs_db.RouterExtraAttributes,
-                          l3_attrs_db.RouterExtraAttributes.router_id ==
-                          RouterL3AgentBinding.router_id).
-                filter(sa.or_(l3_attrs_db.RouterExtraAttributes.ha ==
-                              sql.false(),
-                              l3_attrs_db.RouterExtraAttributes.ha ==
-                              sql.null())))
-
-            agents_back_online = set()
-            for binding in down_bindings:
-                if binding.l3_agent_id in agents_back_online:
-                    continue
-                else:
-                    # we need new context to make sure we use different DB
-                    # transaction - otherwise we may fetch same agent record
-                    # each time due to REPEATABLE_READ isolation level
-                    context = n_ctx.get_admin_context()
-                    agent = self._get_agent(context, binding.l3_agent_id)
-                    if agent.is_active:
-                        agents_back_online.add(binding.l3_agent_id)
-                        continue
-
-                LOG.warning(_LW(
-                    "Rescheduling router %(router)s from agent %(agent)s "
-                    "because the agent did not report to the server in "
-                    "the last %(dead_time)s seconds."),
-                    {'router': binding.router_id,
-                     'agent': binding.l3_agent_id,
-                     'dead_time': agent_dead_limit})
-                try:
-                    self.reschedule_router(context, binding.router_id)
-                except (l3agentscheduler.RouterReschedulingFailed,
-                        oslo_messaging.RemoteError):
-                    # Catch individual router rescheduling errors here
-                    # so one broken one doesn't stop the iteration.
-                    LOG.exception(_LE("Failed to reschedule router %s"),
-                                  binding.router_id)
-        except Exception:
-            # we want to be thorough and catch whatever is raised
-            # to avoid loop abortion
-            LOG.exception(_LE("Exception encountered during router "
-                              "rescheduling."))
+    def get_down_router_bindings(self, context, agent_dead_limit):
+            cutoff = self.get_cutoff_time(agent_dead_limit)
+            return (context.session.query(RouterL3AgentBinding).
+                    join(agents_db.Agent).
+                    filter(agents_db.Agent.heartbeat_timestamp < cutoff,
+                    agents_db.Agent.admin_state_up).
+                    outerjoin(l3_attrs_db.RouterExtraAttributes,
+                    l3_attrs_db.RouterExtraAttributes.router_id ==
+                    RouterL3AgentBinding.router_id).filter(
+                    sa.or_(
+                        l3_attrs_db.RouterExtraAttributes.ha == sql.false(),
+                        l3_attrs_db.RouterExtraAttributes.ha == sql.null())))
 
     def _get_agent_mode(self, agent_db):
         agent_conf = self.get_configuration_dict(agent_db)


### PR DESCRIPTION
Generalise the logic of resource auto rescheduling

The logic of reschedule_routers_from_down_agents() can be useful for
additional types of resource rescheduling such as loadbalancers, as described at
Id8d3218bf1e52722cc10ddcd34e3e734eef90658

Related-Bug: #1565511

Change-Id: I7871d68246d82f343e99730c09f81bcc7800bcce
